### PR TITLE
feat: crea SPA per certificar menús sense al·lèrgens

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/web/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+npm run lint
+npm run test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Facturit-Aibar (tecnologia) + DN/TA (20 anys d'experiència)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,111 @@
-# allercheck
-El concepte de seguretat alimentària certificada i validada tecnològicament
+# Certificació de Menús Lliures d’Al·lèrgens
+
+Aplicació web per a la certificació de menús sense al·lèrgens en entorns de restauració col·lectiva. El projecte prioritza la traçabilitat, la doble validació DN/TA i l’auditoria completa, amb dades en local (IndexedDB o LocalStorage) i exportacions en formats CSV i HTML imprimible.
+
+## Característiques principals
+
+- **SPA amb React + TypeScript + Vite** i estil amb Tailwind CSS.
+- **Gestió d’estat amb Zustand** per datasets, validacions i auditories.
+- **Motor de validació** que detecta errors, riscos per traces i revisions pendents per canvis de proveïdor.
+- **Doble validació** amb segells DN (1/2) i TA (2/2) fins assolir estat “Certificat”.
+- **Exportacions**: CSV de validacions i d’auditoria, informe HTML imprimible (compatible amb “Desa com a PDF”).
+- **Seeds de demostració** amb comensals, menús, plats, ingredients i proveïdors.
+- **Auditoria** amb registres abans/després, usuari, rol i hash curt del dataset.
+- **Mode demo** amb anonimització opcional de comensals i toggles de mòduls addicionals.
+- **Testing amb Vitest + Testing Library**, **ESLint + Prettier**, **Husky (pre-commit)** i workflow de GitHub Actions per desplegar a GitHub Pages.
+
+## Requisits
+
+- Node.js 20 o superior.
+- Navegador modern per accedir a l’aplicació.
+
+## Instal·lació i execució
+
+A la primera instal·lació, afegiu les dependències del workspace:
+
+```bash
+npm install
+```
+
+Executa l’entorn de desenvolupament (Vite):
+
+```bash
+npm run dev
+```
+
+Construeix la versió de producció:
+
+```bash
+npm run build
+```
+
+Previsualitza la compilació:
+
+```bash
+npm run preview
+```
+
+Executa el linter i els tests:
+
+```bash
+npm run lint
+npm run test
+```
+
+### Scripts del frontend (`apps/web`)
+
+Els scripts principals també estan disponibles des del paquet intern:
+
+- `npm -w apps/web run dev`
+- `npm -w apps/web run build`
+- `npm -w apps/web run preview`
+- `npm -w apps/web run lint`
+- `npm -w apps/web run test`
+- `npm -w apps/web run deploy`
+
+### Husky
+
+El repositori inclou Husky. Després d’instal·lar les dependències executeu `npm run prepare` per crear `.husky/` i configurar el hook pre-commit (executa `npm run lint && npm run test`).
+
+## Emmagatzematge local
+
+Per defecte s’utilitza `localStorage`. Podeu canviar a IndexedDB (Dexie) definint l’entorn Vite:
+
+```bash
+VITE_STORAGE_BACKEND=dexie npm run dev
+```
+
+Les dades persistides inclouen menús, comensals, proveïdors, auditories i estats de validació. El mòdul de configuració permet regenerar les dades de prova o netejar l’emmagatzematge.
+
+## Exportacions
+
+- **CSV**: des de la vista de menús (validacions) i des de la vista d’auditoria.
+- **Informe HTML/PDF**: botó “Informe imprimible” a cada menú (es pot imprimir o desar com a PDF des del navegador).
+- **Impressió global**: botó “Imprimeix / Desa PDF” a la capçalera per generar una vista imprimible general.
+
+## Seeds de demostració
+
+El botó “Genera dades de prova” reestableix el dataset inicial amb:
+
+- 3 comensals: celiaquia, al·lèrgia severa a fruits secs i intolerància a la lactosa.
+- 5 plats, incloent receptes conflictives i amb traces.
+- 2 proveïdors amb canvi de versió de fitxa.
+- Flux complet de validació, incidències i segells DN/TA.
+
+## Testing
+
+Els tests de `Vitest` verifiquen el motor de validació d’al·lèrgens (errors, riscos i revisions). Executeu `npm run test` per validar-los.
+
+## Desplegament a GitHub Pages
+
+El workflow `.github/workflows/pages.yml` construeix l’app quan es fa push a `main` i desplega a la branca `gh-pages`. Per publicar manualment:
+
+```bash
+npm run deploy
+```
+
+Ajusteu `base` a `vite.config.ts` si el repositori té un nom diferent.
+
+## Llicència
+
+MIT — © 2024 Facturit-Aibar (tecnologia) + DN/TA (20 anys d’experiència).

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  plugins: ['react'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off'
+  }
+};

--- a/apps/web/.prettierrc
+++ b/apps/web/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 100
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ca">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Certificació de Menús Lliures d’Al·lèrgens</title>
+    <link rel="stylesheet" href="/src/styles/print.css" media="print" />
+  </head>
+  <body class="min-h-screen">
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "test": "vitest",
+    "deploy": "gh-pages -d dist"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "dexie": "^4.0.4",
+    "nanoid": "^5.0.7",
+    "papaparse": "^5.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "gh-pages": "^6.0.0",
+    "jsdom": "^24.0.0",
+    "postcss": "^8.4.35",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.4",
+    "vitest": "^2.0.0"
+  }
+}

--- a/apps/web/postcss.config.cjs
+++ b/apps/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useState } from 'react';
+import { BrowserRouter, Navigate, Route, Routes, NavLink } from 'react-router-dom';
+import { useDataStore } from '../store/dataStore';
+import { ToastProvider } from '../components/ToastProvider';
+import { DashboardPage } from '../features/dashboard/DashboardPage';
+import { ComensalsPage } from '../features/comensals/ComensalsPage';
+import { MenusPage } from '../features/menus/MenusPage';
+import { PlatsPage } from '../features/plats/PlatsPage';
+import { ProveidorsPage } from '../features/proveidors/ProveidorsPage';
+import { ValidacioPage } from '../features/validacio/ValidacioPage';
+import { AuditoriaPage } from '../features/auditoria/AuditoriaPage';
+import { ConfiguracioPage } from '../features/configuracio/ConfiguracioPage';
+import { TEXTS } from '../lib/texts';
+
+const routes = [
+  { path: '/dashboard', label: TEXTS.sidebar.dashboard, element: <DashboardPage /> },
+  { path: '/comensals', label: TEXTS.sidebar.comensals, element: <ComensalsPage /> },
+  { path: '/menus', label: TEXTS.sidebar.menus, element: <MenusPage /> },
+  { path: '/plats', label: TEXTS.sidebar.plats, element: <PlatsPage /> },
+  { path: '/proveidors', label: TEXTS.sidebar.proveidors, element: <ProveidorsPage /> },
+  { path: '/validacio', label: TEXTS.sidebar.validacio, element: <ValidacioPage /> },
+  { path: '/auditoria', label: TEXTS.sidebar.auditoria, element: <AuditoriaPage /> },
+  { path: '/configuracio', label: TEXTS.sidebar.configuracio, element: <ConfiguracioPage /> }
+];
+
+function Layout() {
+  const [darkMode, setDarkMode] = useState(false);
+  const { data } = useDataStore();
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  const navLinks = useMemo(
+    () =>
+      routes.map((route) => (
+        <NavLink
+          key={route.path}
+          to={route.path}
+          className={({ isActive }) =>
+            `flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+              isActive
+                ? 'bg-primary-600 text-white'
+                : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+            }`
+          }
+        >
+          {route.label}
+        </NavLink>
+      )),
+    []
+  );
+
+  return (
+    <div className="flex min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
+      <aside className="sticky top-0 flex h-screen w-64 flex-col gap-4 border-r border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900">
+        <div>
+          <p className="text-xs font-semibold uppercase text-primary-500">Certificació</p>
+          <h1 className="text-lg font-bold">{TEXTS.appTitle}</h1>
+        </div>
+        <nav className="flex flex-1 flex-col gap-1 overflow-auto">{navLinks}</nav>
+        <div className="space-y-2 text-xs text-slate-500 dark:text-slate-400">
+          <p>{TEXTS.banners.demo}</p>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={darkMode}
+              onChange={() => setDarkMode((value) => !value)}
+              className="h-4 w-4 rounded border-slate-300"
+            />
+            Mode fosc
+          </label>
+          <p>Dades: {data.toggles.rols ? 'Rols actius' : 'Rols ocults'}</p>
+        </div>
+      </aside>
+      <main className="flex-1">
+        <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+            <h2 className="text-xl font-semibold">Certificació contínua · Menús segurs</h2>
+            <button
+              onClick={() => window.print()}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+            >
+              Imprimeix / Desa PDF
+            </button>
+          </div>
+        </header>
+        <div className="mx-auto max-w-6xl space-y-8 px-6 py-8">
+          <Routes>
+            {routes.map((route) => (
+              <Route key={route.path} path={route.path} element={route.element} />
+            ))}
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function AppInner() {
+  const init = useDataStore((state) => state.init);
+  const hydrated = useDataStore((state) => state.hydrated);
+
+  useEffect(() => {
+    void init();
+  }, [init]);
+
+  if (!hydrated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-900">
+        <p className="text-sm text-slate-500">Carregant dades de certificació…</p>
+      </div>
+    );
+  }
+
+  return <Layout />;
+}
+
+export function App() {
+  return (
+    <ToastProvider>
+      <BrowserRouter>
+        <AppInner />
+      </BrowserRouter>
+    </ToastProvider>
+  );
+}

--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -1,0 +1,17 @@
+import type { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost';
+}
+
+export function Button({ variant = 'primary', className, ...props }: ButtonProps) {
+  const base =
+    'inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+  const variants: Record<Required<ButtonProps>['variant'], string> = {
+    primary: 'bg-primary-600 hover:bg-primary-700 text-white focus:ring-primary-500',
+    secondary: 'bg-slate-200 hover:bg-slate-300 text-slate-900 focus:ring-slate-400 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-100',
+    ghost: 'bg-transparent hover:bg-slate-200 text-slate-900 dark:text-slate-100 dark:hover:bg-slate-700'
+  };
+  return <button className={clsx(base, variants[variant], className)} {...props} />;
+}

--- a/apps/web/src/components/KpiCard.tsx
+++ b/apps/web/src/components/KpiCard.tsx
@@ -1,0 +1,15 @@
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  trend?: string;
+}
+
+export function KpiCard({ title, value, trend }: KpiCardProps) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+      <p className="text-sm font-medium text-slate-500">{title}</p>
+      <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100">{value}</p>
+      {trend ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{trend}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/SeverityBadge.tsx
+++ b/apps/web/src/components/SeverityBadge.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx';
+import { TEXTS } from '../lib/texts';
+import type { IncidentSeveritat } from '../lib/types';
+
+const colorMap: Record<IncidentSeveritat, string> = {
+  ERROR: 'bg-red-100 text-red-900 dark:bg-red-900 dark:text-red-100',
+  RISC: 'bg-yellow-100 text-yellow-900 dark:bg-yellow-900 dark:text-yellow-100',
+  REVISIO: 'bg-indigo-100 text-indigo-900 dark:bg-indigo-900 dark:text-indigo-100'
+};
+
+export function SeverityBadge({ severitat }: { severitat: IncidentSeveritat }) {
+  return (
+    <span className={clsx('rounded-full px-2 py-1 text-xs font-semibold', colorMap[severitat])}>
+      {TEXTS.severitat[severitat]}
+    </span>
+  );
+}

--- a/apps/web/src/components/StatusBadge.tsx
+++ b/apps/web/src/components/StatusBadge.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx';
+import { TEXTS } from '../lib/texts';
+import type { EstatValidacio } from '../lib/types';
+
+const colorMap: Record<EstatValidacio, string> = {
+  BORRADOR: 'bg-slate-200 text-slate-800 dark:bg-slate-700 dark:text-slate-100',
+  VALIDAT_1_2: 'bg-blue-100 text-blue-900 dark:bg-blue-900 dark:text-blue-100',
+  VALIDAT_2_2: 'bg-indigo-100 text-indigo-900 dark:bg-indigo-900 dark:text-indigo-100',
+  CERTIFICAT: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900 dark:text-emerald-100',
+  REVISIO: 'bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100'
+};
+
+export function StatusBadge({ estat }: { estat: EstatValidacio }) {
+  return (
+    <span className={clsx('rounded-full px-3 py-1 text-xs font-semibold', colorMap[estat])}>
+      {TEXTS.estatLabels[estat]}
+    </span>
+  );
+}

--- a/apps/web/src/components/Table.tsx
+++ b/apps/web/src/components/Table.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+
+interface TableProps {
+  headers: ReactNode[];
+  rows: ReactNode[][];
+  emptyMessage?: string;
+}
+
+export function Table({ headers, rows, emptyMessage = 'Sense dades' }: TableProps) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
+      <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+        <thead className="bg-slate-100 dark:bg-slate-800">
+          <tr>
+            {headers.map((header, index) => (
+              <th
+                key={index}
+                scope="col"
+                className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300"
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-700 dark:bg-slate-900">
+          {rows.length === 0 ? (
+            <tr>
+              <td colSpan={headers.length} className="px-4 py-6 text-center text-sm text-slate-500">
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            rows.map((cols, rowIndex) => (
+              <tr key={rowIndex} className="hover:bg-slate-50 dark:hover:bg-slate-800">
+                {cols.map((col, colIndex) => (
+                  <td key={colIndex} className="px-4 py-3 text-sm text-slate-700 dark:text-slate-200">
+                    {col}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/ToastProvider.tsx
+++ b/apps/web/src/components/ToastProvider.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+
+interface Toast {
+  id: string;
+  message: string;
+  type?: 'info' | 'success' | 'error';
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  showToast: (message: string, type?: Toast['type']) => void;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const createId = () => (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}`);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      toasts,
+      showToast: (message, type = 'info') => {
+        const toast = { id: createId(), message, type };
+        setToasts((current) => [...current, toast]);
+        setTimeout(() => {
+          setToasts((current) => current.filter((item) => item.id !== toast.id));
+        }, 5000);
+      },
+      dismissToast: (id) => setToasts((current) => current.filter((item) => item.id !== id))
+    }),
+    [toasts]
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="fixed bottom-6 right-6 z-50 space-y-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            role="status"
+            className={
+              'flex max-w-xs items-start gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-900'
+            }
+          >
+            <span className="font-semibold text-slate-700 dark:text-slate-100">
+              {toast.type === 'error' ? '⚠️' : toast.type === 'success' ? '✅' : 'ℹ️'}
+            </span>
+            <p className="text-slate-700 dark:text-slate-100">{toast.message}</p>
+            <button
+              onClick={() => value.dismissToast(toast.id)}
+              className="ml-auto text-slate-400 hover:text-slate-600"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast s\'ha d\'utilitzar dins de ToastProvider');
+  }
+  return context;
+}

--- a/apps/web/src/data/seeds.ts
+++ b/apps/web/src/data/seeds.ts
@@ -1,0 +1,223 @@
+import type { PersistedState } from '../lib/types';
+
+export const seedState: PersistedState = {
+  comensals: [
+    {
+      id: 'com-anna',
+      nom: 'Anna Vidal',
+      dieta: 'Sense gluten',
+      informes: [
+        {
+          id: 'inf-anna-2024',
+          dataISO: '2024-04-01',
+          notes: 'Celíaca. Control estricte.',
+          alergies: [{ codi: 'gluten', severitat: 'alta' }]
+        }
+      ]
+    },
+    {
+      id: 'com-marc',
+      nom: 'Marc Pérez',
+      dieta: 'Sense fruits secs',
+      informes: [
+        {
+          id: 'inf-marc-2024',
+          dataISO: '2024-03-20',
+          alergies: [{ codi: 'fruits-secs', severitat: 'alta' }]
+        }
+      ]
+    },
+    {
+      id: 'com-laura',
+      nom: 'Laura Solé',
+      dieta: 'Sense lactosa',
+      informes: [
+        {
+          id: 'inf-laura-2024',
+          dataISO: '2024-02-18',
+          alergies: [{ codi: 'lactosa', severitat: 'moderada' }]
+        }
+      ]
+    }
+  ],
+  proveidors: [
+    {
+      id: 'prov-aliseg',
+      nom: 'Aliments Segurs SCCL',
+      fitxes: [
+        {
+          versio: '2024.04',
+          dataISO: '2024-04-15',
+          declaracioAlergens: [
+            { codi: 'gluten', present: false },
+            { codi: 'fruits-secs', present: false },
+            { codi: 'lactosa', present: false }
+          ]
+        },
+        {
+          versio: '2023.12',
+          dataISO: '2023-12-01',
+          declaracioAlergens: [
+            { codi: 'gluten', present: false },
+            { codi: 'fruits-secs', present: false },
+            { codi: 'lactosa', present: true, potContenir: true }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'prov-dolc',
+      nom: 'Dolça Tradició SL',
+      fitxes: [
+        {
+          versio: '2024.02',
+          dataISO: '2024-02-10',
+          declaracioAlergens: [
+            { codi: 'gluten', present: true },
+            { codi: 'fruits-secs', present: true, potContenir: true },
+            { codi: 'lactosa', present: false }
+          ]
+        }
+      ]
+    }
+  ],
+  ingredients: [
+    {
+      id: 'ing-pasta',
+      nom: 'Pasta de blat',
+      proveidorId: 'prov-dolc',
+      alergens: ['gluten'],
+      potContenir: ['fruits-secs'],
+      dataDeclaracio: '2024-02-10'
+    },
+    {
+      id: 'ing-crema',
+      nom: 'Crema de llet',
+      proveidorId: 'prov-aliseg',
+      alergens: ['lactosa'],
+      dataDeclaracio: '2023-12-01'
+    },
+    {
+      id: 'ing-galetes',
+      nom: 'Galetes cruixents',
+      proveidorId: 'prov-dolc',
+      alergens: ['gluten'],
+      potContenir: ['fruits-secs'],
+      dataDeclaracio: '2024-02-10'
+    },
+    {
+      id: 'ing-brou',
+      nom: 'Brou vegetal',
+      proveidorId: 'prov-aliseg',
+      alergens: [],
+      dataDeclaracio: '2024-04-15'
+    },
+    {
+      id: 'ing-fruita',
+      nom: 'Fruita de temporada',
+      proveidorId: 'prov-aliseg',
+      alergens: [],
+      dataDeclaracio: '2024-04-15'
+    }
+  ],
+  plats: [
+    {
+      id: 'plat-pasta-bolonyesa',
+      nom: 'Pasta a la bolonyesa',
+      ingredients: [
+        { idIng: 'ing-pasta', quantitat: 120, unitat: 'g' },
+        { idIng: 'ing-brou', quantitat: 50, unitat: 'ml' }
+      ],
+      alergensDerivats: ['gluten'],
+      versio: '2024.01',
+      cost: 3.2
+    },
+    {
+      id: 'plat-crema-lactosa',
+      nom: 'Crema suau de llet',
+      ingredients: [
+        { idIng: 'ing-crema', quantitat: 150, unitat: 'ml' },
+        { idIng: 'ing-brou', quantitat: 50, unitat: 'ml' }
+      ],
+      alergensDerivats: ['lactosa'],
+      versio: '2024.01',
+      cost: 2.7
+    },
+    {
+      id: 'plat-galetes',
+      nom: 'Galetes cruixents',
+      ingredients: [{ idIng: 'ing-galetes', quantitat: 60, unitat: 'g' }],
+      alergensDerivats: ['gluten'],
+      versio: '2024.01',
+      cost: 1.2
+    },
+    {
+      id: 'plat-amanida',
+      nom: 'Amanida fresca',
+      ingredients: [{ idIng: 'ing-fruita', quantitat: 120, unitat: 'g' }],
+      versio: '2024.01',
+      cost: 1.8
+    },
+    {
+      id: 'plat-brou',
+      nom: 'Brou vegetal',
+      ingredients: [{ idIng: 'ing-brou', quantitat: 200, unitat: 'ml' }],
+      versio: '2024.01',
+      cost: 1.5
+    }
+  ],
+  menus: [
+    {
+      id: 'menu-dia1',
+      dataISO: '2024-05-10',
+      torn: 'dinar',
+      plats: ['plat-pasta-bolonyesa', 'plat-amanida'],
+      assignacions: [
+        { comensalId: 'com-anna', platId: 'plat-amanida' },
+        { comensalId: 'com-marc', platId: 'plat-pasta-bolonyesa' },
+        { comensalId: 'com-laura', platId: 'plat-amanida' }
+      ],
+      estat: 'BORRADOR',
+      segells: []
+    },
+    {
+      id: 'menu-dia2',
+      dataISO: '2024-05-11',
+      torn: 'dinar',
+      plats: ['plat-crema-lactosa', 'plat-galetes'],
+      assignacions: [
+        { comensalId: 'com-anna', platId: 'plat-galetes' },
+        { comensalId: 'com-marc', platId: 'plat-galetes' },
+        { comensalId: 'com-laura', platId: 'plat-crema-lactosa' }
+      ],
+      estat: 'BORRADOR',
+      segells: []
+    }
+  ],
+  canvis: [
+    {
+      id: 'canvi-001',
+      tipus: 'FITXA_PROVEIDOR',
+      entitatId: 'prov-aliseg',
+      descripcio: 'Nova declaració 2024.04 sense lactosa',
+      dataISO: '2024-04-15'
+    },
+    {
+      id: 'canvi-002',
+      tipus: 'RECEPTARI',
+      entitatId: 'plat-pasta-bolonyesa',
+      descripcio: 'Ajust quantitats per ració infantil',
+      dataISO: '2024-03-05'
+    }
+  ],
+  auditories: [],
+  toggles: {
+    nutricional: false,
+    escandall: false,
+    compres: false,
+    conservacio: false,
+    plansPreu: false,
+    rols: true
+  },
+  anonimitza: false
+};

--- a/apps/web/src/features/auditoria/AuditoriaPage.tsx
+++ b/apps/web/src/features/auditoria/AuditoriaPage.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Table } from '../../components/Table';
+import { exportAuditCsv } from '../../lib/export';
+import { formatISO } from '../../lib/date';
+import { Button } from '../../components/Button';
+
+export function AuditoriaPage() {
+  const { data } = useDataStore();
+
+  const rows = useMemo(() => {
+    return data.auditories.map((entrada) => [
+      entrada.tipus,
+      entrada.usuari,
+      entrada.rol,
+      formatISO(entrada.dataISO),
+      entrada.accio,
+      <code key={`${entrada.id}-abans`} className="whitespace-pre-wrap text-xs">{entrada.abans}</code>,
+      <code key={`${entrada.id}-despres`} className="whitespace-pre-wrap text-xs">{entrada.despres}</code>,
+      entrada.hash
+    ]);
+  }, [data.auditories]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Registre d'auditoria</h3>
+          <p className="text-sm text-slate-500">
+            Traçabilitat completa d'accions, amb hash curt del dataset en el moment de cada operació.
+          </p>
+        </div>
+        <Button variant="secondary" onClick={() => exportAuditCsv(data.auditories)}>
+          Exporta auditoria CSV
+        </Button>
+      </div>
+      <Table
+        headers={['Tipus', 'Usuari', 'Rol', 'Data', 'Acció', 'Abans', 'Després', 'Hash']}
+        rows={rows}
+        emptyMessage="Encara no hi ha accions registrades"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/comensals/ComensalsPage.tsx
+++ b/apps/web/src/features/comensals/ComensalsPage.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Table } from '../../components/Table';
+import { formatISO } from '../../lib/date';
+
+export function ComensalsPage() {
+  const { data } = useDataStore();
+  const [search, setSearch] = useState('');
+  const [filterAlergen, setFilterAlergen] = useState('');
+
+  const alergensDisponibles = useMemo(() => {
+    const set = new Set<string>();
+    data.comensals.forEach((comensal) => {
+      comensal.informes.forEach((informe) => {
+        informe.alergies.forEach((alergia) => set.add(alergia.codi));
+      });
+    });
+    return Array.from(set.values());
+  }, [data.comensals]);
+
+  const rows = useMemo(() => {
+    return data.comensals
+      .filter((comensal) =>
+        `${comensal.nom} ${comensal.dieta ?? ''}`.toLowerCase().includes(search.toLowerCase())
+      )
+      .filter((comensal) =>
+        filterAlergen
+          ? comensal.informes.some((informe) =>
+              informe.alergies.some((alergia) => alergia.codi === filterAlergen)
+            )
+          : true
+      )
+      .map((comensal, index) => {
+        const informe = [...comensal.informes].sort((a, b) => (a.dataISO < b.dataISO ? 1 : -1))[0];
+        const nom = data.anonimitza ? `Com-${index + 1}` : comensal.nom;
+        return [
+          nom,
+          comensal.dieta ?? 'General',
+          informe ? formatISO(informe.dataISO) : 'n/d',
+          informe
+            ? informe.alergies
+                .map((alergia) => `${alergia.codi} (${alergia.severitat})`)
+                .join(', ')
+            : 'Sense registres'
+        ];
+      });
+  }, [data, filterAlergen, search]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end">
+        <div className="flex-1">
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            Cerca per nom o dieta
+          </label>
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900"
+            placeholder="Ex. sense gluten"
+          />
+        </div>
+        <div className="w-full md:w-64">
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            Filtra per al·lergogen
+          </label>
+          <select
+            value={filterAlergen}
+            onChange={(event) => setFilterAlergen(event.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900"
+          >
+            <option value="">Tots</option>
+            {alergensDisponibles.map((alergogen) => (
+              <option key={alergogen} value={alergogen}>
+                {alergogen}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <Table headers={["Comensal", 'Dieta', 'Darrera revisió', 'Al·lèrgies registrades']} rows={rows} />
+    </div>
+  );
+}

--- a/apps/web/src/features/configuracio/ConfiguracioPage.tsx
+++ b/apps/web/src/features/configuracio/ConfiguracioPage.tsx
@@ -1,0 +1,54 @@
+import { useDataStore } from '../../store/dataStore';
+import { storageBackend } from '../../lib/storage';
+import { Button } from '../../components/Button';
+import { TEXTS } from '../../lib/texts';
+
+export function ConfiguracioPage() {
+  const { data } = useDataStore();
+  const toggleFeature = useDataStore((state) => state.toggleFeature);
+  const toggleAnonimitza = useDataStore((state) => state.toggleAnonimitza);
+  const applySeed = useDataStore((state) => state.applySeed);
+  const clearData = useDataStore((state) => state.clearData);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-lg font-semibold">Opcions del sistema</h3>
+        <p className="text-sm text-slate-500">Backend d'emmagatzematge: {storageBackend}</p>
+        <p className="text-sm text-slate-500">Funcions de rols: {data.toggles.rols ? 'Actives' : 'Inactives'}</p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Button variant="secondary" onClick={() => applySeed()}>
+            {TEXTS.actions.generacioSeeds}
+          </Button>
+          <Button variant="ghost" onClick={() => clearData()}>
+            {TEXTS.actions.neteja}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <h4 className="text-md font-semibold">Mòduls opcionals</h4>
+          <div className="mt-3 space-y-2 text-sm">
+            {Object.entries(data.toggles).map(([key, value]) => (
+              <label key={key} className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2 dark:border-slate-700">
+                <span className="capitalize">{key}</span>
+                <input type="checkbox" checked={value} onChange={() => toggleFeature(key as keyof typeof data.toggles)} />
+              </label>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <h4 className="text-md font-semibold">Protecció de dades demo</h4>
+          <label className="mt-2 flex items-center justify-between rounded-md border border-slate-200 px-3 py-2 text-sm dark:border-slate-700">
+            <span>Anonimitza noms de comensals</span>
+            <input type="checkbox" checked={data.anonimitza} onChange={() => toggleAnonimitza()} />
+          </label>
+          <p className="mt-2 text-xs text-slate-500">
+            Quan s'activa, les taules mostren codis enlloc de noms reals per facilitar la compartició d'informes.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { KpiCard } from '../../components/KpiCard';
+import { StatusBadge } from '../../components/StatusBadge';
+import { SeverityBadge } from '../../components/SeverityBadge';
+import { Table } from '../../components/Table';
+import { formatISO } from '../../lib/date';
+
+export function DashboardPage() {
+  const data = useDataStore((state) => state.data);
+  const validations = useDataStore((state) => state.validations);
+  const validateAll = useDataStore((state) => state.validateAll);
+
+  const totals = useMemo(() => {
+    const totalMenus = data.menus.length;
+    const certificats = data.menus.filter((menu) => menu.estat === 'CERTIFICAT').length;
+    const revisions = data.menus.filter((menu) => menu.estat === 'REVISIO').length;
+    const pendents = totalMenus - certificats - revisions;
+    const incidentsTotals = Object.values(validations).reduce((acc, summary) => acc + summary.incidents.length, 0);
+    const errors = Object.values(validations).reduce(
+      (acc, summary) => acc + summary.incidents.filter((incident) => incident.severitat === 'ERROR').length,
+      0
+    );
+    return { totalMenus, certificats, revisions, pendents, incidentsTotals, errors };
+  }, [data.menus, validations]);
+
+  const incidentsRecents = useMemo(() => {
+    return Object.values(validations)
+      .flatMap((summary) => summary.incidents.map((incident) => ({ ...incident, menuId: summary.menuId })))
+      .sort((a, b) => (a.id < b.id ? 1 : -1))
+      .slice(0, 5);
+  }, [validations]);
+
+  const menusPerSegell = useMemo(() => {
+    return data.menus.map((menu) => ({
+      id: menu.id,
+      estat: menu.estat,
+      segells: menu.segells
+        .map((segell) => `${segell.rol} (${formatISO(segell.dataISO)})`)
+        .join(', ') || 'Sense segell'
+    }));
+  }, [data.menus]);
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <KpiCard title="Menús totals" value={totals.totalMenus} />
+        <KpiCard title="Certificats" value={totals.certificats} trend={`Pendents: ${totals.pendents}`} />
+        <KpiCard title="Revisions" value={totals.revisions} trend={`Errors crítics: ${totals.errors}`} />
+        <KpiCard title="Incidències" value={totals.incidentsTotals} trend="Validació contínua" />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Estat global de validacions</h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Resultats del motor de validació. Torneu a executar per actualitzar canvis de proveïdor o receptari.
+          </p>
+        </div>
+        <button
+          onClick={() => validateAll()}
+          className="rounded-md border border-primary-200 bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-primary-700"
+        >
+          Revalida tots els menús
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-4">
+          <h4 className="text-md font-semibold">Incidències recents</h4>
+          <Table
+            headers={['Menú', 'Severitat', 'Al·lergogen', 'Comensal', 'Descripció']}
+            rows={incidentsRecents.map((incident) => [
+              incident.menuId,
+              <SeverityBadge key={incident.id} severitat={incident.severitat} />,
+              incident.alergogen,
+              incident.comensalId,
+              incident.descripcio
+            ])}
+            emptyMessage="Sense incidències registrades"
+          />
+        </div>
+        <div className="space-y-4">
+          <h4 className="text-md font-semibold">Segells i certificacions</h4>
+          <Table
+            headers={['Menú', 'Estat', 'Segells']}
+            rows={menusPerSegell.map((row) => [
+              row.id,
+              <StatusBadge key={row.id} estat={row.estat} />,
+              row.segells
+            ])}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/menus/MenusPage.tsx
+++ b/apps/web/src/features/menus/MenusPage.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { StatusBadge } from '../../components/StatusBadge';
+import { SeverityBadge } from '../../components/SeverityBadge';
+import { Table } from '../../components/Table';
+import { Button } from '../../components/Button';
+import { exportValidationCsv, openPrintableReport } from '../../lib/export';
+import { formatISO } from '../../lib/date';
+import { useToast } from '../../components/ToastProvider';
+import { TEXTS } from '../../lib/texts';
+
+export function MenusPage() {
+  const { data, validations } = useDataStore();
+  const validateMenu = useDataStore((state) => state.validateMenu);
+  const addSegell = useDataStore((state) => state.addSegell);
+  const resetSegells = useDataStore((state) => state.resetSegells);
+  const [filterEstat, setFilterEstat] = useState('');
+  const [search, setSearch] = useState('');
+  const { showToast } = useToast();
+
+  const menusFiltrats = useMemo(() => {
+    return data.menus
+      .filter((menu) => (filterEstat ? menu.estat === filterEstat : true))
+      .filter((menu) =>
+        search
+          ? menu.assignacions.some((assignacio) => assignacio.comensalId.toLowerCase().includes(search.toLowerCase())) ||
+            menu.plats.some((platId) => platId.toLowerCase().includes(search.toLowerCase()))
+          : true
+      );
+  }, [data.menus, filterEstat, search]);
+
+  const rows = menusFiltrats.map((menu) => {
+    const summary = validations[menu.id];
+    const incidents = summary?.incidents ?? [];
+    const errors = incidents.filter((incident) => incident.severitat === 'ERROR').length;
+    const riscos = incidents.filter((incident) => incident.severitat === 'RISC').length;
+    const revisions = incidents.filter((incident) => incident.severitat === 'REVISIO').length;
+
+    return [
+      <div key={`${menu.id}-info`} className="space-y-1">
+        <p className="font-medium">{menu.id}</p>
+        <p className="text-xs text-slate-500">{formatISO(menu.dataISO)} · {menu.torn}</p>
+      </div>,
+      <StatusBadge key={`${menu.id}-estat`} estat={menu.estat} />,
+      <div key={`${menu.id}-incidents`} className="flex flex-wrap gap-2">
+        {errors > 0 && <SeverityBadge severitat="ERROR" />}
+        {riscos > 0 && <SeverityBadge severitat="RISC" />}
+        {revisions > 0 && <SeverityBadge severitat="REVISIO" />}
+        {incidents.length === 0 && <span className="text-xs text-emerald-600">Cap incidència</span>}
+      </div>,
+      <div key={`${menu.id}-segells`} className="space-y-1 text-xs">
+        {menu.segells.length === 0 ? (
+          <span className="text-slate-500">Sense segells</span>
+        ) : (
+          menu.segells.map((segell) => (
+            <div key={segell.rol}>
+              {segell.rol} · {segell.usuari} · {formatISO(segell.dataISO)}
+            </div>
+          ))
+        )}
+      </div>,
+      <div key={`${menu.id}-accions`} className="flex flex-wrap gap-2">
+        <Button
+          variant="secondary"
+          onClick={() => {
+            validateMenu(menu.id);
+            showToast(`Validació executada per ${menu.id}`, 'success');
+          }}
+        >
+          {TEXTS.actions.validar}
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() => {
+            if (!summary) {
+              showToast('Executa la validació abans d\'exportar', 'error');
+              return;
+            }
+            openPrintableReport(menu, summary, data);
+          }}
+        >
+          {TEXTS.actions.exportarInforme}
+        </Button>
+        <Button
+          variant="primary"
+          disabled={errors > 0 || revisions > 0}
+          onClick={() => {
+            addSegell(menu.id, { rol: 'DN', usuari: 'DN demo', dataISO: new Date().toISOString() });
+            showToast(`Segell DN aplicat al menú ${menu.id}`);
+          }}
+        >
+          {TEXTS.actions.segellDN}
+        </Button>
+        <Button
+          variant="primary"
+          disabled={errors > 0 || revisions > 0 || !menu.segells.some((segell) => segell.rol === 'DN')}
+          onClick={() => {
+            addSegell(menu.id, { rol: 'TA', usuari: 'TA demo', dataISO: new Date().toISOString() });
+            showToast(`Segell TA aplicat al menú ${menu.id}`);
+          }}
+        >
+          {TEXTS.actions.segellTA}
+        </Button>
+        <Button variant="ghost" onClick={() => resetSegells(menu.id)}>
+          Reinicia segells
+        </Button>
+      </div>
+    ];
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <label className="text-sm text-slate-600 dark:text-slate-300">Filtra per estat</label>
+          <select
+            value={filterEstat}
+            onChange={(event) => setFilterEstat(event.target.value)}
+            className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900"
+          >
+            <option value="">Tots</option>
+            {Object.entries(TEXTS.estatLabels).map(([key, label]) => (
+              <option key={key} value={key}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Cerca per comensal o plat"
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 md:w-80"
+        />
+        <Button variant="secondary" onClick={() => exportValidationCsv(Object.values(validations))}>
+          {TEXTS.actions.exportarCsv}
+        </Button>
+      </div>
+      <Table
+        headers={['Menú', 'Estat', 'Incidències', 'Segells', 'Accions']}
+        rows={rows}
+        emptyMessage="Cap menú amb el filtre actual"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/plats/PlatsPage.tsx
+++ b/apps/web/src/features/plats/PlatsPage.tsx
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Table } from '../../components/Table';
+
+export function PlatsPage() {
+  const { data } = useDataStore();
+
+  const rows = useMemo(() => {
+    const ingredientsById = Object.fromEntries(data.ingredients.map((ingredient) => [ingredient.id, ingredient] as const));
+    return data.plats.map((plat) => {
+      const ingredients = plat.ingredients
+        .map((item) => ingredientsById[item.idIng])
+        .filter(Boolean)
+        .map((ingredient) => `${ingredient!.nom} (${ingredient!.alergens.join(', ') || 'cap'})`)
+        .join(', ');
+      const alergens = plat.alergensDerivats?.join(', ') ?? 'cap';
+      const cost = data.toggles.escandall && plat.cost ? `${plat.cost.toFixed(2)} €` : '-';
+      return [plat.nom, plat.versio, ingredients, alergens, cost];
+    });
+  }, [data.ingredients, data.plats, data.toggles.escandall]);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-500">
+        Receptari i traçabilitat d\'ingredients segons la darrera declaració de proveïdor.
+      </p>
+      <Table headers={['Plat', 'Versió', 'Ingredients', 'Al·lèrgens', 'Cost']} rows={rows} />
+    </div>
+  );
+}

--- a/apps/web/src/features/proveidors/ProveidorsPage.tsx
+++ b/apps/web/src/features/proveidors/ProveidorsPage.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Table } from '../../components/Table';
+import { formatISO } from '../../lib/date';
+
+export function ProveidorsPage() {
+  const { data } = useDataStore();
+
+  const rows = useMemo(() => {
+    return data.proveidors.map((proveidor) => {
+      const latest = [...proveidor.fitxes].sort((a, b) => (a.dataISO < b.dataISO ? 1 : -1))[0];
+      const declaracions = latest.declaracioAlergens
+        .map((item) => `${item.codi}: ${item.present ? 'Present' : 'Absència'}${item.potContenir ? ' (pot contenir)' : ''}`)
+        .join(' · ');
+      const ingredientsAfectats = data.ingredients
+        .filter((ingredient) => ingredient.proveidorId === proveidor.id)
+        .filter((ingredient) => ingredient.dataDeclaracio < latest.dataISO).length;
+      return [
+        proveidor.nom,
+        latest.versio,
+        formatISO(latest.dataISO),
+        declaracions,
+        ingredientsAfectats > 0 ? `${ingredientsAfectats} ingredients a revisar` : 'Actualitzat'
+      ];
+    });
+  }, [data.ingredients, data.proveidors]);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-500">
+        Control de fitxes tècniques i versions. Si hi ha una versió nova cal revisar els ingredients associats.
+      </p>
+      <Table headers={['Proveïdor', 'Versió', 'Data', 'Declaració', 'Revisions']} rows={rows} />
+    </div>
+  );
+}

--- a/apps/web/src/features/validacio/ValidacioPage.tsx
+++ b/apps/web/src/features/validacio/ValidacioPage.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'react';
+import { useDataStore } from '../../store/dataStore';
+import { Table } from '../../components/Table';
+import { SeverityBadge } from '../../components/SeverityBadge';
+
+export function ValidacioPage() {
+  const { data, validations } = useDataStore();
+  const summaries = Object.values(validations);
+  const [filterSeveritat, setFilterSeveritat] = useState('');
+  const [filterAlergen, setFilterAlergen] = useState('');
+
+  const incidents = useMemo(() => {
+    return summaries.flatMap((summary) =>
+      summary.incidents.map((incident) => ({ ...incident, menuId: summary.menuId, generatedAt: summary.generatedAt }))
+    );
+  }, [summaries]);
+
+  const alergensDisponibles = useMemo(() => {
+    const set = new Set<string>();
+    incidents.forEach((incident) => set.add(incident.alergogen));
+    return Array.from(set.values());
+  }, [incidents]);
+
+  const filtered = incidents.filter((incident) =>
+    (filterSeveritat ? incident.severitat === filterSeveritat : true) &&
+    (filterAlergen ? incident.alergogen === filterAlergen : true)
+  );
+
+  const rows = filtered.map((incident) => [
+    incident.menuId,
+    incident.comensalId,
+    incident.platId,
+    <SeverityBadge key={incident.id} severitat={incident.severitat} />,
+    incident.alergogen,
+    incident.descripcio,
+    `${incident.traçabilitat.ingredientId} → ${incident.traçabilitat.proveidorId} (${incident.traçabilitat.versioFitxa ?? 'n/d'})`
+  ]);
+
+  const alternatives = useMemo(() => {
+    return data.comensals.map((comensal) => {
+      const alergens = new Set(
+        comensal.informes.flatMap((informe) => informe.alergies.map((alergia) => alergia.codi))
+      );
+      const platsSegurs = data.plats
+        .filter((plat) => !(plat.alergensDerivats ?? []).some((alergen) => alergens.has(alergen)))
+        .map((plat) => plat.nom);
+      return { comensal: comensal.nom, platsSegurs };
+    });
+  }, [data.comensals, data.plats]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end">
+        <div className="w-full md:w-48">
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">Severitat</label>
+          <select
+            value={filterSeveritat}
+            onChange={(event) => setFilterSeveritat(event.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900"
+          >
+            <option value="">Totes</option>
+            <option value="ERROR">Errors</option>
+            <option value="RISC">Risc</option>
+            <option value="REVISIO">Revisió</option>
+          </select>
+        </div>
+        <div className="w-full md:w-64">
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">Al·lergogen</label>
+          <select
+            value={filterAlergen}
+            onChange={(event) => setFilterAlergen(event.target.value)}
+            className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900"
+          >
+            <option value="">Tots</option>
+            {alergensDisponibles.map((alergogen) => (
+              <option key={alergogen} value={alergogen}>
+                {alergogen}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <Table
+        headers={['Menú', 'Comensal', 'Plat', 'Severitat', 'Al·lergogen', 'Descripció', 'Traçabilitat']}
+        rows={rows}
+        emptyMessage="Sense incidències amb el filtre aplicat"
+      />
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h4 className="text-md font-semibold">Alternatives compatibles per dieta</h4>
+        <div className="mt-2 space-y-2 text-sm">
+          {alternatives.map((item) => (
+            <p key={item.comensal}>
+              <span className="font-semibold">{item.comensal}:</span> {item.platsSegurs.join(', ') || 'Cal definir alternatives'}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './styles/tailwind.css';
+import { App } from './app/App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -1,0 +1,7 @@
+export function formatISO(date: string): string {
+  return new Date(date).toLocaleDateString('ca-ES');
+}
+
+export function nowISO(): string {
+  return new Date().toISOString();
+}

--- a/apps/web/src/lib/export.ts
+++ b/apps/web/src/lib/export.ts
@@ -1,0 +1,148 @@
+import Papa from 'papaparse';
+import { formatISO } from './date';
+import type { AuditEntry, Menu, PersistedState, ValidationSummary } from './types';
+
+function downloadBlob(filename: string, blob: Blob) {
+  if (typeof window === 'undefined') return;
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(link.href), 0);
+}
+
+export function exportValidationCsv(summaries: ValidationSummary[]) {
+  const rows = summaries.flatMap((summary) =>
+    summary.incidents.map((incident) => ({
+      menuId: summary.menuId,
+      dataValidacio: formatISO(summary.generatedAt),
+      comensalId: incident.comensalId,
+      platId: incident.platId,
+      alergogen: incident.alergogen,
+      severitat: incident.severitat,
+      descripcio: incident.descripcio,
+      proveidor: incident.traçabilitat.proveidorId,
+      ingredient: incident.traçabilitat.ingredientId,
+      versio: incident.traçabilitat.versioFitxa ?? 'n/d'
+    }))
+  );
+  const csv = Papa.unparse(rows);
+  downloadBlob(`validacions-${Date.now()}.csv`, new Blob([csv], { type: 'text/csv' }));
+}
+
+export function exportAuditCsv(entries: AuditEntry[]) {
+  const rows = entries.map((entry) => ({
+    id: entry.id,
+    tipus: entry.tipus,
+    usuari: entry.usuari,
+    rol: entry.rol,
+    data: formatISO(entry.dataISO),
+    accio: entry.accio,
+    abans: entry.abans,
+    despres: entry.despres,
+    hash: entry.hash
+  }));
+  const csv = Papa.unparse(rows);
+  downloadBlob(`auditoria-${Date.now()}.csv`, new Blob([csv], { type: 'text/csv' }));
+}
+
+export function openPrintableReport(menu: Menu, summary: ValidationSummary, data: PersistedState) {
+  if (typeof window === 'undefined') return;
+  const comensalsById = Object.fromEntries(data.comensals.map((c) => [c.id, c] as const));
+  const platsById = Object.fromEntries(data.plats.map((p) => [p.id, p] as const));
+  const html = `<!DOCTYPE html>
+  <html lang="ca">
+    <head>
+      <meta charset="utf-8" />
+      <title>Informe de certificació ${menu.id}</title>
+      <style>
+        body { font-family: 'Inter', sans-serif; margin: 2rem; }
+        header { border-bottom: 2px solid #0f88ff; margin-bottom: 1rem; padding-bottom: 1rem; }
+        h1 { font-size: 1.8rem; margin: 0; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
+        th, td { border: 1px solid #d1d5db; padding: 0.5rem; text-align: left; }
+        th { background: #f3f4f6; }
+        .badge { padding: 0.25rem 0.5rem; border-radius: 0.5rem; display: inline-block; }
+        .error { background: #fee2e2; color: #b91c1c; }
+        .risk { background: #fef3c7; color: #b45309; }
+        .review { background: #e0e7ff; color: #3730a3; }
+      </style>
+    </head>
+    <body>
+      <header>
+        <h1>Informe de certificació</h1>
+        <p>Menú ${formatISO(menu.dataISO)} (${menu.torn}) · Estat: ${menu.estat}</p>
+        <p>Segells: ${menu.segells
+          .map((s) => `${s.rol} - ${s.usuari} (${formatISO(s.dataISO)})`)
+          .join(', ') || 'Cap'}</p>
+      </header>
+      <section>
+        <h2>Assignacions</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Comensal</th>
+              <th>Plat</th>
+              <th>Dieta</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${menu.assignacions
+              .map((assignacio) => {
+                const comensal = comensalsById[assignacio.comensalId];
+                const plat = platsById[assignacio.platId];
+                return `<tr><td>${comensal?.nom ?? assignacio.comensalId}</td><td>${
+                  plat?.nom ?? assignacio.platId
+                }</td><td>${comensal?.dieta ?? 'n/d'}</td></tr>`;
+              })
+              .join('')}
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Incidències</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Severitat</th>
+              <th>Comensal</th>
+              <th>Plat</th>
+              <th>Al·lergogen</th>
+              <th>Descripció</th>
+              <th>Traçabilitat</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${summary.incidents
+              .map((incident) => {
+                const badgeClass =
+                  incident.severitat === 'ERROR'
+                    ? 'badge error'
+                    : incident.severitat === 'RISC'
+                    ? 'badge risk'
+                    : 'badge review';
+                return `<tr>
+                  <td><span class="${badgeClass}">${incident.severitat}</span></td>
+                  <td>${comensalsById[incident.comensalId]?.nom ?? incident.comensalId}</td>
+                  <td>${platsById[incident.platId]?.nom ?? incident.platId}</td>
+                  <td>${incident.alergogen}</td>
+                  <td>${incident.descripcio}</td>
+                  <td>${incident.traçabilitat.ingredientId} · ${incident.traçabilitat.proveidorId} · ${
+                  incident.traçabilitat.versioFitxa ?? 'n/d'
+                }</td>
+                </tr>`;
+              })
+              .join('')}
+          </tbody>
+        </table>
+      </section>
+    </body>
+  </html>`;
+  const popup = window.open('', '_blank');
+  if (!popup) return;
+  popup.document.write(html);
+  popup.document.close();
+  popup.focus();
+}

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -1,0 +1,69 @@
+import Dexie from 'dexie';
+import type { PersistedState } from './types';
+
+const STORAGE_KEY = 'certi-menus-state';
+
+type StorageBackend = 'localStorage' | 'dexie';
+
+interface StorageClient {
+  load(): Promise<PersistedState | undefined>;
+  save(data: PersistedState): Promise<void>;
+  clear(): Promise<void>;
+}
+
+class DexieClient implements StorageClient {
+  private db: Dexie;
+
+  constructor() {
+    this.db = new Dexie('certi-menus');
+    this.db.version(1).stores({ snapshots: 'id' });
+  }
+
+  async load(): Promise<PersistedState | undefined> {
+    const row = await (this.db.table('snapshots') as Dexie.Table<{ id: number; data: PersistedState }, number>).get(
+      1
+    );
+    return row?.data;
+  }
+
+  async save(data: PersistedState): Promise<void> {
+    await (this.db.table('snapshots') as Dexie.Table<{ id: number; data: PersistedState }, number>).put({
+      id: 1,
+      data
+    });
+  }
+
+  async clear(): Promise<void> {
+    await (this.db.table('snapshots') as Dexie.Table<{ id: number; data: PersistedState }, number>).clear();
+  }
+}
+
+class LocalStorageClient implements StorageClient {
+  async load(): Promise<PersistedState | undefined> {
+    if (typeof localStorage === 'undefined') return undefined;
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value ? (JSON.parse(value) as PersistedState) : undefined;
+  }
+
+  async save(data: PersistedState): Promise<void> {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+
+  async clear(): Promise<void> {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+export function createStorageClient(kind: StorageBackend): StorageClient {
+  if (kind === 'dexie') {
+    return new DexieClient();
+  }
+  return new LocalStorageClient();
+}
+
+export const storageBackend: StorageBackend =
+  (import.meta.env.VITE_STORAGE_BACKEND as StorageBackend) || 'localStorage';
+
+export const storageClient = createStorageClient(storageBackend);

--- a/apps/web/src/lib/texts.ts
+++ b/apps/web/src/lib/texts.ts
@@ -1,0 +1,37 @@
+export const TEXTS = {
+  appTitle: 'Certificació de Menús Lliures d\'Al·lèrgens',
+  sidebar: {
+    dashboard: 'Quadre de comandament',
+    comensals: 'Comensals',
+    menus: 'Menús',
+    plats: 'Plats',
+    proveidors: 'Proveïdors',
+    validacio: 'Validació',
+    auditoria: 'Auditoria',
+    configuracio: 'Configuració'
+  },
+  actions: {
+    validar: 'Executa validació',
+    exportarCsv: 'Exporta CSV',
+    exportarInforme: 'Informe imprimible',
+    segellDN: 'Segell DN (1/2)',
+    segellTA: 'Segell TA (2/2)',
+    generacioSeeds: 'Genera dades de prova',
+    neteja: 'Neteja dades'
+  },
+  estatLabels: {
+    BORRADOR: 'Borrador',
+    VALIDAT_1_2: 'Validat 1/2',
+    VALIDAT_2_2: 'Validat 2/2',
+    CERTIFICAT: 'Certificat',
+    REVISIO: 'Revisió requerida'
+  },
+  severitat: {
+    ERROR: 'Error crític',
+    RISC: 'Risc',
+    REVISIO: 'Revisió'
+  },
+  banners: {
+    demo: 'Dades de demostració sense PII real. Personalitzeu abans de desplegar.'
+  }
+};

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,0 +1,151 @@
+export type AlergoCodi = 'gluten' | 'fruits-secs' | 'lactosa' | string;
+
+export interface InformeMedic {
+  id: string;
+  dataISO: string;
+  notes?: string;
+  alergies: {
+    codi: AlergoCodi;
+    severitat: 'baixa' | 'moderada' | 'alta';
+  }[];
+}
+
+export interface Comensal {
+  id: string;
+  nom: string;
+  dieta?: string;
+  informes: InformeMedic[];
+}
+
+export interface FitxaProveidor {
+  versio: string;
+  dataISO: string;
+  declaracioAlergens: {
+    codi: AlergoCodi;
+    present: boolean;
+    potContenir?: boolean;
+  }[];
+}
+
+export interface Proveidor {
+  id: string;
+  nom: string;
+  fitxes: FitxaProveidor[];
+}
+
+export interface Ingredient {
+  id: string;
+  nom: string;
+  proveidorId: string;
+  alergens: AlergoCodi[];
+  potContenir?: AlergoCodi[];
+  dataDeclaracio: string;
+}
+
+export interface PlatIngredient {
+  idIng: string;
+  quantitat: number;
+  unitat: 'g' | 'ml' | 'u';
+}
+
+export interface Plat {
+  id: string;
+  nom: string;
+  ingredients: PlatIngredient[];
+  alergensDerivats?: AlergoCodi[];
+  versio: string;
+  cost?: number;
+}
+
+export interface Assignacio {
+  comensalId: string;
+  platId: string;
+}
+
+export type EstatValidacio =
+  | 'BORRADOR'
+  | 'VALIDAT_1_2'
+  | 'VALIDAT_2_2'
+  | 'CERTIFICAT'
+  | 'REVISIO';
+
+export interface Segell {
+  rol: 'DN' | 'TA';
+  usuari: string;
+  dataISO: string;
+}
+
+export interface Menu {
+  id: string;
+  dataISO: string;
+  torn: 'esmorzar' | 'dinar' | 'sopar';
+  plats: string[];
+  assignacions: Assignacio[];
+  estat: EstatValidacio;
+  segells: Segell[];
+}
+
+export interface Canvi {
+  id: string;
+  tipus: 'FITXA_PROVEIDOR' | 'RECEPTARI' | 'ALTRE';
+  entitatId: string;
+  descripcio: string;
+  dataISO: string;
+}
+
+export type IncidentSeveritat = 'ERROR' | 'RISC' | 'REVISIO';
+
+export interface Traçabilitat {
+  ingredientId: string;
+  proveidorId: string;
+  versioFitxa?: string;
+}
+
+export interface ValidationIncident {
+  id: string;
+  comensalId: string;
+  platId: string;
+  alergogen: AlergoCodi;
+  severitat: IncidentSeveritat;
+  descripcio: string;
+  traçabilitat: Traçabilitat;
+}
+
+export interface ValidationSummary {
+  menuId: string;
+  incidents: ValidationIncident[];
+  generatedAt: string;
+}
+
+export interface AuditEntry {
+  id: string;
+  tipus: string;
+  usuari: string;
+  rol: string;
+  dataISO: string;
+  accio: string;
+  abans: string;
+  despres: string;
+  hash: string;
+}
+
+export interface FeatureToggles {
+  nutricional: boolean;
+  escandall: boolean;
+  compres: boolean;
+  conservacio: boolean;
+  plansPreu: boolean;
+  rols: boolean;
+}
+
+export interface PersistedState {
+  comensals: Comensal[];
+  proveidors: Proveidor[];
+  ingredients: Ingredient[];
+  plats: Plat[];
+  menus: Menu[];
+  canvis: Canvi[];
+  auditories: AuditEntry[];
+  toggles: FeatureToggles;
+  anonimitza: boolean;
+}

--- a/apps/web/src/lib/validation.test.ts
+++ b/apps/web/src/lib/validation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { validateMenu } from './validation';
+import { seedState } from '../data/seeds';
+
+describe('motor de validació d\'al·lèrgens', () => {
+  it('marca error quan hi ha un al·lergogen prohibit', () => {
+    const summary = validateMenu(seedState.menus[1], seedState);
+    const error = summary.incidents.find((incident) => incident.severitat === 'ERROR');
+    expect(error?.alergogen).toBe('gluten');
+  });
+
+  it('marca risc per traces declarades', () => {
+    const summary = validateMenu(seedState.menus[0], seedState);
+    const risc = summary.incidents.find((incident) => incident.severitat === 'RISC');
+    expect(risc?.alergogen).toBe('fruits-secs');
+  });
+
+  it('marca revisió quan hi ha canvi de fitxa de proveïdor', () => {
+    const customState: typeof seedState = {
+      ...seedState,
+      ingredients: seedState.ingredients.map((ingredient) =>
+        ingredient.id === 'ing-crema'
+          ? { ...ingredient, dataDeclaracio: '2023-10-01' }
+          : ingredient
+      )
+    };
+    const summary = validateMenu(customState.menus[1], customState);
+    const revisio = summary.incidents.find((incident) => incident.severitat === 'REVISIO');
+    expect(revisio).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/validation.ts
+++ b/apps/web/src/lib/validation.ts
@@ -1,0 +1,137 @@
+import { nanoid } from 'nanoid';
+import type {
+  AlergoCodi,
+  Comensal,
+  Ingredient,
+  Menu,
+  PersistedState,
+  Plat,
+  Proveidor,
+  ValidationIncident,
+  ValidationSummary
+} from './types';
+
+function lastInforme(comensal: Comensal) {
+  return [...comensal.informes].sort((a, b) => (a.dataISO < b.dataISO ? 1 : -1))[0];
+}
+
+function getPlatIngredients(plat: Plat, ingredients: Ingredient[]): Ingredient[] {
+  const map = new Map(ingredients.map((ingredient) => [ingredient.id, ingredient] as const));
+  return plat.ingredients
+    .map((item) => map.get(item.idIng))
+    .filter((item): item is Ingredient => Boolean(item));
+}
+
+function hasLatestFitxa(proveidor: Proveidor, ingredient: Ingredient): boolean {
+  const sorted = [...proveidor.fitxes].sort((a, b) => (a.dataISO < b.dataISO ? 1 : -1));
+  const latest = sorted[0];
+  return !latest || latest.dataISO <= ingredient.dataDeclaracio;
+}
+
+function incidentFor(
+  comensal: Comensal,
+  plat: Plat,
+  ingredient: Ingredient,
+  alergogen: AlergoCodi,
+  severitat: ValidationIncident['severitat'],
+  descripcio: string,
+  proveidor: Proveidor
+): ValidationIncident {
+  const latestFitxa = [...proveidor.fitxes].sort((a, b) => (a.dataISO < b.dataISO ? 1 : -1))[0];
+  return {
+    id: nanoid(),
+    comensalId: comensal.id,
+    platId: plat.id,
+    alergogen,
+    severitat,
+    descripcio,
+    traçabilitat: {
+      ingredientId: ingredient.id,
+      proveidorId: proveidor.id,
+      versioFitxa: latestFitxa?.versio
+    }
+  };
+}
+
+export function validateMenu(menu: Menu, data: PersistedState): ValidationSummary {
+  const comensals = new Map(data.comensals.map((c) => [c.id, c] as const));
+  const plats = new Map(data.plats.map((p) => [p.id, p] as const));
+  const ingredients = data.ingredients;
+  const proveidors = new Map(data.proveidors.map((p) => [p.id, p] as const));
+
+  const incidents: ValidationIncident[] = [];
+
+  for (const assignacio of menu.assignacions) {
+    const comensal = comensals.get(assignacio.comensalId);
+    const plat = plats.get(assignacio.platId);
+    if (!comensal || !plat) continue;
+
+    const informe = lastInforme(comensal);
+    if (!informe) continue;
+
+    const alergies = informe.alergies.map((a) => a.codi);
+    const platIngredients = getPlatIngredients(plat, ingredients);
+
+    for (const ingredient of platIngredients) {
+      const proveidor = proveidors.get(ingredient.proveidorId);
+      if (!proveidor) continue;
+
+      for (const alergogen of alergies) {
+        if (ingredient.alergens.includes(alergogen)) {
+          incidents.push(
+            incidentFor(
+              comensal,
+              plat,
+              ingredient,
+              alergogen,
+              'ERROR',
+              `L'ingredient ${ingredient.nom} conté ${alergogen}.`,
+              proveidor
+            )
+          );
+        } else if (ingredient.potContenir?.includes(alergogen)) {
+          incidents.push(
+            incidentFor(
+              comensal,
+              plat,
+              ingredient,
+              alergogen,
+              'RISC',
+              `L'ingredient ${ingredient.nom} pot contenir ${alergogen}.`,
+              proveidor
+            )
+          );
+        }
+      }
+
+      if (!hasLatestFitxa(proveidor, ingredient)) {
+        incidents.push(
+          incidentFor(
+            comensal,
+            plat,
+            ingredient,
+            'revisio-fitxa',
+            'Revisar nova declaració del proveïdor.',
+            proveidor
+          )
+        );
+      }
+    }
+  }
+
+  const cleanedIncidents = incidents.map((incident) =>
+    incident.alergogen === 'revisio-fitxa'
+      ? { ...incident, severitat: 'REVISIO', alergogen: 'fitxa-proveidor' }
+      : incident
+  );
+
+  return {
+    menuId: menu.id,
+    incidents: cleanedIncidents,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+export function summariseAllMenus(data: PersistedState): ValidationSummary[] {
+  return data.menus.map((menu) => validateMenu(menu, data));
+}

--- a/apps/web/src/store/dataStore.ts
+++ b/apps/web/src/store/dataStore.ts
@@ -1,0 +1,185 @@
+import { create } from 'zustand';
+import { nanoid } from 'nanoid';
+import { storageClient } from '../lib/storage';
+import { nowISO } from '../lib/date';
+import { seedState } from '../data/seeds';
+import { summariseAllMenus, validateMenu } from '../lib/validation';
+import type {
+  AuditEntry,
+  Menu,
+  PersistedState,
+  Segell,
+  ValidationSummary
+} from '../lib/types';
+
+const cloneState = (state: PersistedState): PersistedState =>
+  JSON.parse(JSON.stringify(state)) as PersistedState;
+
+interface DataStoreState {
+  data: PersistedState;
+  hydrated: boolean;
+  validations: Record<string, ValidationSummary>;
+  init: () => Promise<void>;
+  validateAll: () => void;
+  validateMenu: (menuId: string) => void;
+  addSegell: (menuId: string, segell: Segell) => void;
+  resetSegells: (menuId: string) => void;
+  applySeed: () => Promise<void>;
+  clearData: () => Promise<void>;
+  toggleFeature: (key: keyof PersistedState['toggles']) => void;
+  toggleAnonimitza: () => void;
+  addAudit: (entry: Omit<AuditEntry, 'id' | 'hash' | 'dataISO'>) => void;
+}
+
+function hashSnapshot(snapshot: unknown): string {
+  const json = JSON.stringify(snapshot);
+  let hash = 0;
+  for (let i = 0; i < json.length; i++) {
+    hash = (hash << 5) - hash + json.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36).slice(0, 8);
+}
+
+function deriveMenuStatus(menu: Menu, summary: ValidationSummary): Menu['estat'] {
+  const hasError = summary.incidents.some((incident) => incident.severitat === 'ERROR');
+  const hasReview = summary.incidents.some((incident) => incident.severitat === 'REVISIO');
+  if (hasReview) return 'REVISIO';
+  if (hasError) return 'BORRADOR';
+
+  const hasDN = menu.segells.some((segell) => segell.rol === 'DN');
+  const hasTA = menu.segells.some((segell) => segell.rol === 'TA');
+  if (hasDN && hasTA) return 'CERTIFICAT';
+  if (hasDN) return 'VALIDAT_1_2';
+  if (hasTA) return 'VALIDAT_2_2';
+  return 'BORRADOR';
+}
+
+async function persistState(data: PersistedState) {
+  await storageClient.save(data);
+}
+
+export const useDataStore = create<DataStoreState>((set, get) => ({
+  data: cloneState(seedState),
+  hydrated: false,
+  validations: {},
+  init: async () => {
+    const persisted = await storageClient.load();
+    const base = persisted ? cloneState(persisted) : cloneState(seedState);
+    set({ data: base, hydrated: true });
+    get().validateAll();
+  },
+  validateAll: () => {
+    const { data } = get();
+    const summaries = summariseAllMenus(data);
+    const validations = Object.fromEntries(summaries.map((summary) => [summary.menuId, summary]));
+    const updatedMenus = data.menus.map((menu) => ({
+      ...menu,
+      estat: deriveMenuStatus(menu, validations[menu.id])
+    }));
+    const updatedState: PersistedState = { ...data, menus: updatedMenus };
+    set({ data: updatedState, validations });
+    void persistState(updatedState);
+  },
+  validateMenu: (menuId: string) => {
+    const { data, validations } = get();
+    const menu = data.menus.find((item) => item.id === menuId);
+    if (!menu) return;
+    const summary = validateMenu(menu, data);
+    const nextValidations = { ...validations, [menuId]: summary };
+    const updatedMenus = data.menus.map((item) =>
+      item.id === menuId ? { ...item, estat: deriveMenuStatus(item, summary) } : item
+    );
+    const updatedState: PersistedState = { ...data, menus: updatedMenus };
+    set({ data: updatedState, validations: nextValidations });
+    void persistState(updatedState);
+  },
+  addSegell: (menuId, segell) => {
+    const { data, addAudit } = get();
+    const menu = data.menus.find((item) => item.id === menuId);
+    if (!menu) return;
+    const segells = menu.segells.filter((item) => item.rol !== segell.rol).concat(segell);
+    const updatedMenus = data.menus.map((item) =>
+      item.id === menuId
+        ? {
+            ...item,
+            segells
+          }
+        : item
+    );
+    const updatedState: PersistedState = { ...data, menus: updatedMenus };
+    const summary = validateMenu({ ...menu, segells }, updatedState);
+    const estat = deriveMenuStatus({ ...menu, segells }, summary);
+    const finalMenus = updatedMenus.map((item) =>
+      item.id === menuId ? { ...item, estat } : item
+    );
+    const finalState: PersistedState = { ...updatedState, menus: finalMenus };
+    set({ data: finalState, validations: { ...get().validations, [menuId]: summary } });
+    void persistState(finalState);
+    addAudit({
+      tipus: 'SEGELL',
+      usuari: segell.usuari,
+      rol: segell.rol,
+      accio: `Afegit segell ${segell.rol} al menú ${menuId}`,
+      abans: JSON.stringify(menu.segells),
+      despres: JSON.stringify(segells)
+    });
+  },
+  resetSegells: (menuId) => {
+    const { data, addAudit } = get();
+    const menu = data.menus.find((item) => item.id === menuId);
+    if (!menu) return;
+    const updatedMenus = data.menus.map((item) =>
+      item.id === menuId ? { ...item, segells: [], estat: 'BORRADOR' } : item
+    );
+    const updatedState: PersistedState = { ...data, menus: updatedMenus };
+    set({ data: updatedState });
+    void persistState(updatedState);
+    addAudit({
+      tipus: 'SEGELL',
+      usuari: 'sistema',
+      rol: 'DN',
+      accio: `Segells reiniciats al menú ${menuId}`,
+      abans: JSON.stringify(menu.segells),
+      despres: '[]'
+    });
+  },
+  applySeed: async () => {
+    const cloned = cloneState(seedState);
+    set({ data: cloned });
+    get().validateAll();
+    await persistState(cloned);
+  },
+  clearData: async () => {
+    await storageClient.clear();
+    const cloned = cloneState(seedState);
+    set({ data: cloned, validations: {} });
+    get().validateAll();
+  },
+  toggleFeature: (key) => {
+    const { data } = get();
+    const toggles = { ...data.toggles, [key]: !data.toggles[key] };
+    const updatedState: PersistedState = { ...data, toggles };
+    set({ data: updatedState });
+    void persistState(updatedState);
+  },
+  toggleAnonimitza: () => {
+    const { data } = get();
+    const updatedState: PersistedState = { ...data, anonimitza: !data.anonimitza };
+    set({ data: updatedState });
+    void persistState(updatedState);
+  },
+  addAudit: (entry) => {
+    const { data } = get();
+    const auditEntry: AuditEntry = {
+      id: nanoid(),
+      dataISO: nowISO(),
+      hash: hashSnapshot(data),
+      ...entry
+    };
+    const auditories = [auditEntry, ...data.auditories].slice(0, 200);
+    const updatedState: PersistedState = { ...data, auditories };
+    set({ data: updatedState });
+    void persistState(updatedState);
+  }
+}));

--- a/apps/web/src/styles/print.css
+++ b/apps/web/src/styles/print.css
@@ -1,0 +1,16 @@
+@media print {
+  body {
+    background: white;
+    color: black;
+    font-size: 12pt;
+  }
+
+  a::after {
+    content: " (" attr(href) ")";
+    font-size: 10pt;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+}

--- a/apps/web/src/styles/tailwind.css
+++ b/apps/web/src/styles/tailwind.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-50;
+}
+
+.print-hidden {
+  @apply print:hidden;
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#edf7ff',
+          100: '#cfe7ff',
+          200: '#9fd0ff',
+          300: '#6fb8ff',
+          400: '#3fa0ff',
+          500: '#0f88ff',
+          600: '#006fdc',
+          700: '#0055a8',
+          800: '#003c74',
+          900: '#002340'
+        }
+      }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/certificacio-menus/',
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  },
+  build: {
+    outDir: 'dist'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "certi-menus",
+  "private": true,
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "dev": "npm -w apps/web run dev",
+    "build": "npm -w apps/web run build",
+    "preview": "npm -w apps/web run preview",
+    "lint": "npm -w apps/web run lint",
+    "test": "npm -w apps/web run test",
+    "deploy": "npm -w apps/web run deploy",
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "husky": "^9.0.11"
+  }
+}


### PR DESCRIPTION
## Summary
- crea l’aplicació React + Vite amb layout, rutes i components per a dashboard, menús, validació, auditoria i configuració
- implementa el magatzem Zustand amb persistència Dexie/localStorage, motor de validació d’al·lèrgens, exportacions CSV/HTML i dades seed
- afegeix tooling de qualitat (ESLint, Prettier, Husky, Vitest), scripts de workspace i workflow de GitHub Pages amb documentació detallada

## Testing
- npm install *(falla: 403 Forbidden al recuperar dependències des del registre npm en aquest entorn)*

------
https://chatgpt.com/codex/tasks/task_e_68e40aadb1f483319c704658f4000cfc